### PR TITLE
Disable Firebase Email Authentication

### DIFF
--- a/backend/services/implementations/authService.ts
+++ b/backend/services/implementations/authService.ts
@@ -202,7 +202,8 @@ class AuthService implements IAuthService {
         .getUser(decodedIdToken.uid);
 
       return (
-        firebaseUser.emailVerified && String(tokenUserId) === requestedUserId
+        // firebaseUser.emailVerified && String(tokenUserId) === requestedUserId
+        tokenUserId === requestedUserId
       );
     } catch (error) {
       return false;

--- a/backend/services/implementations/authService.ts
+++ b/backend/services/implementations/authService.ts
@@ -203,7 +203,7 @@ class AuthService implements IAuthService {
 
       return (
         // firebaseUser.emailVerified && String(tokenUserId) === requestedUserId
-        tokenUserId === requestedUserId
+        String(tokenUserId) === requestedUserId
       );
     } catch (error) {
       return false;


### PR DESCRIPTION
Informal draft PR

I realized that all users will fail the authentication check because we have it set up that you must authenticate your email on firebase. I don't exactly know what this means so for the time being if you need to access the pre built functions, just comment out the verification as shown.

### Steps for reviewers
1. Try to logout, create entity, display entity OR any other task. You should no longer get an authentication error.