### PR TITLE
Add Edit Role API Endpoint

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -61,6 +61,7 @@ const graphQLMiddlewares = {
     deleteSimpleEntity: authorizedByAllRoles(),
     createUser: authorizedByAdmin(),
     updateUser: authorizedByAdmin(),
+    updateUserRole: authorizedByAdmin(),
     deleteUserById: authorizedByAdmin(),
     deleteUserByEmail: authorizedByAdmin(),
     logout: isAuthorizedByUserId("userId"),

--- a/backend/graphql/resolvers/userResolvers.ts
+++ b/backend/graphql/resolvers/userResolvers.ts
@@ -5,7 +5,7 @@ import UserService from "../../services/implementations/userService";
 import IAuthService from "../../services/interfaces/authService";
 import IEmailService from "../../services/interfaces/emailService";
 import IUserService from "../../services/interfaces/userService";
-import { CreateUserDTO, UpdateUserDTO, UserDTO } from "../../types";
+import { CreateUserDTO, Role, UpdateUserDTO, UserDTO } from "../../types";
 import { generateCSV } from "../../utilities/CSVUtils";
 
 const userService: IUserService = new UserService();
@@ -49,6 +49,12 @@ const userResolvers = {
       { id, user }: { id: string; user: UpdateUserDTO },
     ): Promise<UserDTO> => {
       return userService.updateUserById(id, user);
+    },
+    updateUserRole: async (
+      _parent: undefined,
+      { id, role }: { id: string; role: Role },
+    ): Promise<void> => {
+      return userService.updateUserRoleById(id, role);
     },
     deleteUserById: async (
       _parent: undefined,

--- a/backend/graphql/types/userType.ts
+++ b/backend/graphql/types/userType.ts
@@ -27,7 +27,6 @@ const userType = gql`
     firstName: String!
     lastName: String!
     email: String!
-    role: Role!
   }
 
   extend type Query {

--- a/backend/graphql/types/userType.ts
+++ b/backend/graphql/types/userType.ts
@@ -40,6 +40,7 @@ const userType = gql`
   extend type Mutation {
     createUser(user: CreateUserDTO!): UserDTO!
     updateUser(id: ID!, user: UpdateUserDTO!): UserDTO!
+    updateUserRole(id: ID!, role: Role!): ID
     deleteUserById(id: ID!): ID
     deleteUserByEmail(email: String!): ID
   }

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -254,10 +254,9 @@ class UserService implements IUserService {
     };
   }
 
-
   async updateUserRoleById(userId: string, newRole: Role): Promise<void> {
     try {
-      const user = await MgUser.findById(userId)
+      const user = await MgUser.findById(userId);
 
       if (!user) {
         throw new Error(`userId ${userId} not found.`);
@@ -266,15 +265,16 @@ class UserService implements IUserService {
       await MgUser.findByIdAndUpdate(
         userId,
         { role: newRole },
-        { runValidators: true }
+        { runValidators: true },
       );
-
     } catch (error: unknown) {
-      Logger.error(`Failed to update user role. Reason = ${getErrorMessage(error)}`);
+      Logger.error(
+        `Failed to update user role. Reason = ${getErrorMessage(error)}`,
+      );
       throw error;
     }
   }
-  
+
   async deleteUserById(userId: string): Promise<void> {
     try {
       const deletedUser: User | null = await MgUser.findByIdAndDelete(userId);

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -255,6 +255,27 @@ class UserService implements IUserService {
     };
   }
 
+
+  async updateUserRoleById(userId: string, newRole: Role): Promise<void> {
+    try {
+      const user = await MgUser.findById(userId)
+
+      if (!user) {
+        throw new Error(`userId ${userId} not found.`);
+      }
+      // must explicitly specify runValidators when updating through findByIdAndUpdate
+      await MgUser.findByIdAndUpdate(
+        userId,
+        { role: newRole },
+        { runValidators: true }
+      );
+
+    } catch (error: unknown) {
+      Logger.error(`Failed to update user role. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+  }
+  
   async deleteUserById(userId: string): Promise<void> {
     try {
       const deletedUser: User | null = await MgUser.findByIdAndDelete(userId);

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -205,7 +205,7 @@ class UserService implements IUserService {
       // must explicitly specify runValidators when updating through findByIdAndUpdate
       oldUser = await MgUser.findByIdAndUpdate(
         userId,
-        { firstName: user.firstName, lastName: user.lastName, role: user.role },
+        { firstName: user.firstName, lastName: user.lastName },
         { runValidators: true },
       );
 
@@ -225,7 +225,6 @@ class UserService implements IUserService {
             {
               firstName: oldUser.firstName,
               lastName: oldUser.lastName,
-              role: oldUser.role,
             },
             { runValidators: true },
           );
@@ -251,7 +250,7 @@ class UserService implements IUserService {
       firstName: user.firstName,
       lastName: user.lastName,
       email: updatedFirebaseUser.email ?? "",
-      role: user.role,
+      role: oldUser.role,
     };
   }
 

--- a/backend/services/interfaces/userService.ts
+++ b/backend/services/interfaces/userService.ts
@@ -79,6 +79,14 @@ interface IUserService {
   updateUserById(userId: string, user: UpdateUserDTO): Promise<UserDTO>;
 
   /**
+   * Update a  user's role - only accessible by Admin.
+   * @param userId user's id
+   * @param role the new role for the user
+   * @throws Error if role update fails
+   */
+  updateUserRoleById(userId: string, role: string): void | PromiseLike<void>;
+
+  /**
    * Delete a user by id
    * @param userId user's userId
    * @throws Error if user deletion fails


### PR DESCRIPTION
## Notion Ticket Link
<!-- Please replace with your ticket's URL -->
[Create Edit Role API](https://www.notion.so/uwblueprintexecs/1719b5839e45451db0e1c9062365b096?v=85eaf922e0a34b779e45f5f26552c38c&p=511bcb51d31f4fd4b8f68b2416dccd6e&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation Description
* Added a new service to update a user's role by their ID - only accessible by admins
* Added a resolver for the service

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to Test
1. Navigate to the GraphQL playground: localhost:8080/graphql
3. Login using this mutation:
```
mutation Login($email: String!, $password: String!) {
  login(email: $email, password: $password) {
    accessToken
    id
  }
}
```
*Query variables:*
```
{
  "email": "<youremail@uwblueprint.org"",
  "password": "<yourpassword>"
}
```
4. From the MongoDB Console, ensure the account that you are logged in with has the role "Admin", if not you can change it in the console.
5. Open a new tab to run the updateUserRole mutation:
```
mutation UpdateUserRole($id: ID!, $role: Role!) {
  updateUserRole(id: $id, role: $role)
}
```
*Query variables:*
```
{
  "id": "<your id (from the login mutation)>",
  "role": "Volunteer"
}
```
*HTTP Headers:*
[Link for access_token value](https://www.notion.so/uwblueprintexecs/How-To-Test-API-Endpoints-e3bb661a96f94ce9847ae5327bae670c)
```
{
	"authorization": "bearer  <access token (from the login mutation)>",
	"access_token": "<from the notion link above"
}
```
6. The output should be `"updateUserRole": null` since it's a void function. If you try running the query again it will not work since your role should now be Volunteer. Also, can also check that it updated in the MongoDB console.

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR

## Linting & Formatting
### Mac
```bash
docker exec -it CWC-backend /bin/bash -c "yarn fix"
docker exec -it CWC-frontend /bin/bash -c "yarn fix"
```

### Windows
```bash
docker exec -it CWC-backend bash -c "yarn fix"
docker exec -it CWC-frontend bash -c "yarn fix"
```
